### PR TITLE
Added Tailwind React Native Classnames

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,17 +1,18 @@
-import { Button, StyleSheet, Text, View } from "react-native";
-import { useState } from "react";
 import { useFonts } from "expo-font";
+import { useState } from "react";
+import { Button, StyleSheet, Text, View } from "react-native";
 
 import Dripsy from "./components/Dripsy";
 import EmotionNative from "./components/EmotionNative";
-import Native from "./components/ReactNative";
+import Gluestack from "./components/Gluestack";
 import NativeWind from "./components/NativeWind";
+import Native from "./components/ReactNative";
 import Restyle from "./components/Restyle";
 import StyledComponents from "./components/StyledComponents";
 import Tamagui from "./components/Tamagui";
 import TimedRender from "./components/TimedRender";
+import Twrnc from "./components/Twrnc";
 import { Zephyr } from "./components/Zephyr";
-import Gluestack from "./components/Gluestack";
 
 export default function App() {
   const [styleType, setStyleType] = useState(undefined);
@@ -40,6 +41,8 @@ export default function App() {
         return <Zephyr />;
       case "Gluestack":
         return <Gluestack />;
+      case "Twrnc":
+        return <Twrnc />;
       default:
         return null;
     }
@@ -72,6 +75,7 @@ export default function App() {
       />
       <Button title="Zephyr" onPress={onStyleTypePress("Zephyr")} />
       <Button title="Gluestack" onPress={onStyleTypePress("Gluestack")} />
+      <Button title="Twrnc" onPress={onStyleTypePress("Twrnc")} />
       {styleType ? (
         <TimedRender key={styleType}>
           <Text style={styles.text}>

--- a/components/Twrnc.js
+++ b/components/Twrnc.js
@@ -1,0 +1,14 @@
+import { View } from "react-native";
+import tw from "twrnc";
+
+const Twrnc = () => {
+  return (
+    <View style={{ display: "flex", flexDirection: "row" }}>
+      {new Array(1000).fill(0).map((_, i) => (
+        <View key={i} style={tw`border-2 p-1.5 border-red-600`} />
+      ))}
+    </View>
+  );
+};
+
+export default Twrnc;

--- a/package.json
+++ b/package.json
@@ -41,16 +41,17 @@
     "react-native-web": "0.19.7",
     "react-native-zephyr": "1.1.2",
     "styled-components": "6.0.5",
-    "tamagui": "1.47.3"
+    "tamagui": "1.47.3",
+    "twrnc": "^3.6.3"
   },
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@gluestack-style/babel-plugin-styled-resolver": "0.1.14",
     "@tamagui/babel-plugin": "1.47.3",
     "@types/react-native": "0.72.2",
-    "tailwindcss": "3.3.2",
     "react-native": "0.72.3",
-    "react-native-web": "0.19.7"
+    "react-native-web": "0.19.7",
+    "tailwindcss": "3.3.2"
   },
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8419,6 +8419,34 @@ tailwindcss@3.3.2:
     resolve "^1.22.2"
     sucrase "^3.32.0"
 
+tailwindcss@>=2.0.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.3.tgz#90da807393a2859189e48e9e7000e6880a736daf"
+  integrity sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==
+  dependencies:
+    "@alloc/quick-lru" "^5.2.0"
+    arg "^5.0.2"
+    chokidar "^3.5.3"
+    didyoumean "^1.2.2"
+    dlv "^1.1.3"
+    fast-glob "^3.2.12"
+    glob-parent "^6.0.2"
+    is-glob "^4.0.3"
+    jiti "^1.18.2"
+    lilconfig "^2.1.0"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    object-hash "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.23"
+    postcss-import "^15.1.0"
+    postcss-js "^4.0.1"
+    postcss-load-config "^4.0.1"
+    postcss-nested "^6.0.1"
+    postcss-selector-parser "^6.0.11"
+    resolve "^1.22.2"
+    sucrase "^3.32.0"
+
 tamagui@1.47.3:
   version "1.47.3"
   resolved "https://registry.yarnpkg.com/tamagui/-/tamagui-1.47.3.tgz#2cb2fe903aa2806f521cdafb1ec31916c61ab749"
@@ -8643,6 +8671,13 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+
+twrnc@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/twrnc/-/twrnc-3.6.3.tgz#15a17f1f7383bf18238cedf5ea681f9269b55b57"
+  integrity sha512-QzhTVnUAuHixFrxFcgHuUKAc2LVBhJbfnetc3zCGdZ7HPoJvpQC4B+s9QkCV3i2Qti4JHuj4MIabqo+ybWm3kQ==
+  dependencies:
+    tailwindcss ">=2.0.0"
 
 type-detect@4.0.8:
   version "4.0.8"


### PR DESCRIPTION
Added [Tailwind React Native Classnames](https://github.com/jaredh159/tailwind-react-native-classnames) to the mix. It looks like on of the better performing libs both in dev and release mode

### Dev mode slowdown `-19.88%`
<img src="https://github.com/efstathiosntonas/react-native-style-libraries-benchmark/assets/4958587/a942abed-569f-4577-8bb2-84360fe0b009" width="45%" height="45%">
<img src="https://github.com/efstathiosntonas/react-native-style-libraries-benchmark/assets/4958587/b6af8191-9f43-4190-9557-c4a1c6ac5c32" width="45%" height="45%">

### Release mode `-20.93%`
<img src="https://github.com/efstathiosntonas/react-native-style-libraries-benchmark/assets/4958587/4af85ded-d99c-46cc-909b-12b9934bdc9c" width="45%" height="45%">
<img src="https://github.com/efstathiosntonas/react-native-style-libraries-benchmark/assets/4958587/fd6d4451-cad4-471c-afa9-ef80e159e2f2" width="45%" height="45%">


